### PR TITLE
Updated scrot command - added -o to overwrite existing temp file

### DIFF
--- a/part_II/07_i3/dotfiles/i3/scripts/lock.sh
+++ b/part_II/07_i3/dotfiles/i3/scripts/lock.sh
@@ -2,7 +2,7 @@
 
 img=/tmp/i3lock.png
 
-scrot $img
+scrot -o $img
 convert $img -scale 10% -scale 1000% $img
 
 i3lock -u -i $img


### PR DESCRIPTION
On page 115 of the book, there is a script to produce a screenshot of the current visible area, this image is then transformed to give the blur effect. 

I found out that there is a missing flag in `scrot` command . Without this flag, every new screenshot is created with a different name, therefore every time you lock your screen you'll see only the very first image and not the last recent view of the screen.

As per scrot documentation : 
`  -o, --overwrite           By default scrot does not overwrite the files, use this option to allow it.`

The correct invocation line is:
`scrot -o $img`